### PR TITLE
Port to 26.1-snapshot-4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ src/main/generated/
 
 .classpath
 .DS_Store
+/.idea

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,12 @@
 plugins {
-	id "fabric-loom" version "1.9.2"
+	id "fabric-loom" version "1.14.10"
 	id "maven-publish"
 }
 
-archivesBaseName = project.archives_base_name
+base {
+	archivesName = project.archives_base_name
+}
+
 version = project.mod_version
 group = project.maven_group
 
@@ -39,6 +42,7 @@ dependencies {
 	// Fabric API (helper)
 	modImplementation(fabricApi.module("fabric-registry-sync-v0", project.fabric_version))
 	modImplementation(fabricApi.module("fabric-data-generation-api-v1", project.fabric_version))
+	modImplementation(fabricApi.module("fabric-item-group-api-v1", project.fabric_version))
 
 	// Fabric API (direct)
 	modImplementation(fabricApi.module("fabric-object-builder-api-v1", project.fabric_version))

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id "fabric-loom" version "1.14.10"
+	id "net.fabricmc.fabric-loom" version "1.14.10"
 	id "maven-publish"
 }
 
@@ -36,17 +36,16 @@ assemble.dependsOn(runDatagen)
 dependencies {
 	// Main
 	minecraft("com.mojang:minecraft:${project.minecraft_version}")
-	mappings(loom.officialMojangMappings())
-	modImplementation("net.fabricmc:fabric-loader:${project.loader_version}")
+	implementation("net.fabricmc:fabric-loader:${project.loader_version}")
 
 	// Fabric API (helper)
-	modImplementation(fabricApi.module("fabric-registry-sync-v0", project.fabric_version))
-	modImplementation(fabricApi.module("fabric-data-generation-api-v1", project.fabric_version))
-	modImplementation(fabricApi.module("fabric-item-group-api-v1", project.fabric_version))
+	implementation(fabricApi.module("fabric-registry-sync-v0", project.fabric_version))
+	implementation(fabricApi.module("fabric-data-generation-api-v1", project.fabric_version))
+	implementation(fabricApi.module("fabric-creative-tab-api-v1", project.fabric_version))
 
 	// Fabric API (direct)
-	modImplementation(fabricApi.module("fabric-object-builder-api-v1", project.fabric_version))
-	modImplementation(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
+	implementation(fabricApi.module("fabric-object-builder-api-v1", project.fabric_version))
+	implementation(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
 }
 
 processResources {
@@ -58,8 +57,8 @@ processResources {
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ assemble.dependsOn(runDatagen)
 dependencies {
 	// Main
 	minecraft("com.mojang:minecraft:${project.minecraft_version}")
-	mappings("net.fabricmc:yarn:${project.yarn_mappings}:v2")
+	mappings(loom.officialMojangMappings())
 	modImplementation("net.fabricmc:fabric-loader:${project.loader_version}")
 
 	// Fabric API (helper)

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,6 @@ mod_version = 1.12.0
 org.gradle.jvmargs = -Xmx1G
 
 # Versions
-minecraft_version = 1.21.11
-yarn_mappings = 1.21.11+build.1
+minecraft_version = 26.1-snapshot-4
 loader_version = 0.18.4
-fabric_version = 0.141.1+1.21.11
+fabric_version = 0.142.1+26.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ mod_version = 1.12.0
 org.gradle.jvmargs = -Xmx1G
 
 # Versions
-minecraft_version = 1.21.4
-yarn_mappings = 1.21.4+build.1
-loader_version = 0.16.9
-fabric_version = 0.110.5+1.21.4
+minecraft_version = 1.21.11
+yarn_mappings = 1.21.11+build.1
+loader_version = 0.18.4
+fabric_version = 0.141.1+1.21.11

--- a/src/datagen/java/io/github/haykam821/columns/data/ColumnsDatagen.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/ColumnsDatagen.java
@@ -7,7 +7,7 @@ import io.github.haykam821.columns.data.provider.ColumnsModelProvider;
 import io.github.haykam821.columns.data.provider.ColumnsRecipeGenerator;
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
-import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagsProvider;
 
 public class ColumnsDatagen implements DataGeneratorEntrypoint {
 	@Override
@@ -16,7 +16,7 @@ public class ColumnsDatagen implements DataGeneratorEntrypoint {
 
 		pack.addProvider(ColumnsBlockLootTableProvider::new);
 
-		FabricTagProvider.BlockTagProvider blockTags = pack.addProvider(ColumnsBlockTagProvider::new);
+		FabricTagsProvider.BlockTagsProvider blockTags = pack.addProvider(ColumnsBlockTagProvider::new);
 
 		pack.addProvider((dataOutput, registries) -> new ColumnsItemTagProvider(dataOutput, registries, blockTags));
 

--- a/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsBlockLootTableProvider.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsBlockLootTableProvider.java
@@ -3,12 +3,12 @@ package io.github.haykam821.columns.data.provider;
 import java.util.concurrent.CompletableFuture;
 
 import io.github.haykam821.columns.block.ColumnTypes;
-import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
-import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider;
+import net.fabricmc.fabric.api.datagen.v1.FabricPackOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootSubProvider;
 import net.minecraft.core.HolderLookup;
 
-public class ColumnsBlockLootTableProvider extends FabricBlockLootTableProvider {
-	public ColumnsBlockLootTableProvider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries) {
+public class ColumnsBlockLootTableProvider extends FabricBlockLootSubProvider {
+	public ColumnsBlockLootTableProvider(FabricPackOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries) {
 		super(dataOutput, registries);
 	}
 

--- a/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsBlockLootTableProvider.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsBlockLootTableProvider.java
@@ -5,21 +5,21 @@ import java.util.concurrent.CompletableFuture;
 import io.github.haykam821.columns.block.ColumnTypes;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider;
-import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.core.HolderLookup;
 
 public class ColumnsBlockLootTableProvider extends FabricBlockLootTableProvider {
-	public ColumnsBlockLootTableProvider(FabricDataOutput dataOutput, CompletableFuture<RegistryWrapper.WrapperLookup> registries) {
+	public ColumnsBlockLootTableProvider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries) {
 		super(dataOutput, registries);
 	}
 
 	@Override
 	public void generate() {
 		for (ColumnTypes columnType : ColumnTypes.values()) {
-			this.addDrop(columnType.block);
+			this.dropSelf(columnType.block);
 		}
 
-		this.lootTables.forEach((id, lootTable) -> {
-			lootTable.randomSequenceId(id.getValue());
+		this.map.forEach((id, lootTable) -> {
+			lootTable.setRandomSequence(id.identifier());
 		});
 	}
 }

--- a/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsBlockTagProvider.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsBlockTagProvider.java
@@ -6,22 +6,22 @@ import io.github.haykam821.columns.Main;
 import io.github.haykam821.columns.block.ColumnTypes;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
-import net.minecraft.registry.RegistryWrapper;
-import net.minecraft.registry.RegistryWrapper.WrapperLookup;
-import net.minecraft.registry.tag.BlockTags;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderLookup.Provider;
+import net.minecraft.tags.BlockTags;
 
 public class ColumnsBlockTagProvider extends FabricTagProvider.BlockTagProvider {
-	public ColumnsBlockTagProvider(FabricDataOutput dataOutput, CompletableFuture<RegistryWrapper.WrapperLookup> registries) {
+	public ColumnsBlockTagProvider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries) {
 		super(dataOutput, registries);
 	}
 
 	@Override
-	protected void configure(WrapperLookup lookup) {
+	protected void addTags(Provider lookup) {
 		FabricTagBuilder builder = this.getOrCreateTagBuilder(Main.COLUMNS_BLOCK_TAG);
 		for (ColumnTypes columnType : ColumnTypes.values()) {
 			builder.add(columnType.block);
 		}
 
-		this.getOrCreateTagBuilder(BlockTags.PICKAXE_MINEABLE).addTag(Main.COLUMNS_BLOCK_TAG);
+		this.getOrCreateTagBuilder(BlockTags.MINEABLE_WITH_PICKAXE).addTag(Main.COLUMNS_BLOCK_TAG);
 	}
 }

--- a/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsBlockTagProvider.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsBlockTagProvider.java
@@ -4,24 +4,26 @@ import java.util.concurrent.CompletableFuture;
 
 import io.github.haykam821.columns.Main;
 import io.github.haykam821.columns.block.ColumnTypes;
-import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
-import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
+import net.fabricmc.fabric.api.datagen.v1.FabricPackOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagsProvider;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.HolderLookup.Provider;
+import net.minecraft.data.tags.TagAppender;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.block.Block;
 
-public class ColumnsBlockTagProvider extends FabricTagProvider.BlockTagProvider {
-	public ColumnsBlockTagProvider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries) {
+public class ColumnsBlockTagProvider extends FabricTagsProvider.BlockTagsProvider {
+	public ColumnsBlockTagProvider(FabricPackOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries) {
 		super(dataOutput, registries);
 	}
 
 	@Override
 	protected void addTags(Provider lookup) {
-		FabricTagBuilder builder = this.getOrCreateTagBuilder(Main.COLUMNS_BLOCK_TAG);
+		TagAppender<Block, Block> builder = this.valueLookupBuilder(Main.COLUMNS_BLOCK_TAG);
 		for (ColumnTypes columnType : ColumnTypes.values()) {
 			builder.add(columnType.block);
 		}
 
-		this.getOrCreateTagBuilder(BlockTags.MINEABLE_WITH_PICKAXE).addTag(Main.COLUMNS_BLOCK_TAG);
+		this.valueLookupBuilder(BlockTags.MINEABLE_WITH_PICKAXE).addTag(Main.COLUMNS_BLOCK_TAG);
 	}
 }

--- a/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsItemTagProvider.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsItemTagProvider.java
@@ -5,16 +5,16 @@ import java.util.concurrent.CompletableFuture;
 import io.github.haykam821.columns.Main;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
-import net.minecraft.registry.RegistryWrapper;
-import net.minecraft.registry.RegistryWrapper.WrapperLookup;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderLookup.Provider;
 
 public class ColumnsItemTagProvider extends FabricTagProvider.ItemTagProvider {
-	public ColumnsItemTagProvider(FabricDataOutput dataOutput, CompletableFuture<RegistryWrapper.WrapperLookup> registries, FabricTagProvider.BlockTagProvider blockTags) {
+	public ColumnsItemTagProvider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries, FabricTagProvider.BlockTagProvider blockTags) {
 		super(dataOutput, registries, blockTags);
 	}
 
 	@Override
-	protected void configure(WrapperLookup lookup) {
+	protected void addTags(Provider lookup) {
 		this.copy(Main.COLUMNS_BLOCK_TAG, Main.COLUMNS_ITEM_TAG);
 	}
 }

--- a/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsItemTagProvider.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsItemTagProvider.java
@@ -3,13 +3,13 @@ package io.github.haykam821.columns.data.provider;
 import java.util.concurrent.CompletableFuture;
 
 import io.github.haykam821.columns.Main;
-import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
-import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
+import net.fabricmc.fabric.api.datagen.v1.FabricPackOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagsProvider;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.HolderLookup.Provider;
 
-public class ColumnsItemTagProvider extends FabricTagProvider.ItemTagProvider {
-	public ColumnsItemTagProvider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries, FabricTagProvider.BlockTagProvider blockTags) {
+public class ColumnsItemTagProvider extends FabricTagsProvider.ItemTagsProvider {
+	public ColumnsItemTagProvider(FabricPackOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries, FabricTagsProvider.BlockTagsProvider blockTags) {
 		super(dataOutput, registries, blockTags);
 	}
 

--- a/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsModelProvider.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsModelProvider.java
@@ -7,60 +7,60 @@ import io.github.haykam821.columns.block.ColumnBlock;
 import io.github.haykam821.columns.block.ColumnTypes;
 import net.fabricmc.fabric.api.client.datagen.v1.provider.FabricModelProvider;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
-import net.minecraft.block.Block;
-import net.minecraft.block.Blocks;
-import net.minecraft.client.data.BlockStateModelGenerator;
 import net.minecraft.client.data.BlockStateVariant;
-import net.minecraft.client.data.ItemModelGenerator;
-import net.minecraft.client.data.Model;
 import net.minecraft.client.data.MultipartBlockStateSupplier;
-import net.minecraft.client.data.TextureKey;
-import net.minecraft.client.data.TextureMap;
 import net.minecraft.client.data.VariantSettings;
 import net.minecraft.client.data.When;
-import net.minecraft.util.Identifier;
+import net.minecraft.client.data.models.BlockModelGenerators;
+import net.minecraft.client.data.models.ItemModelGenerators;
+import net.minecraft.client.data.models.model.ModelTemplate;
+import net.minecraft.client.data.models.model.TextureMapping;
+import net.minecraft.client.data.models.model.TextureSlot;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 
 public class ColumnsModelProvider extends FabricModelProvider {
-	public static final Model COLUMN_CENTER = createModel("column_center", "_center", TextureKey.ALL);
-	public static final Model COLUMN_END = createModel("column_end", "_end", TextureKey.ALL);
-	public static final Model COLUMN_INVENTORY = createModel("column_inventory", "_inventory", TextureKey.ALL);
+	public static final ModelTemplate COLUMN_CENTER = createModel("column_center", "_center", TextureSlot.ALL);
+	public static final ModelTemplate COLUMN_END = createModel("column_end", "_end", TextureSlot.ALL);
+	public static final ModelTemplate COLUMN_INVENTORY = createModel("column_inventory", "_inventory", TextureSlot.ALL);
 
 	public ColumnsModelProvider(FabricDataOutput dataOutput) {
 		super(dataOutput);
 	}
 
 	@Override
-	public void generateBlockStateModels(BlockStateModelGenerator modelGenerator) {
+	public void generateBlockStateModels(BlockModelGenerators modelGenerator) {
 		for (ColumnTypes columnType : ColumnTypes.values()) {
 			ColumnsModelProvider.registerColumn(modelGenerator, columnType.block, columnType.base);
 		}
 	}
 
 	@Override
-	public void generateItemModels(ItemModelGenerator modelGenerator) {
+	public void generateItemModels(ItemModelGenerators modelGenerator) {
 		return;
 	}
 
-	public static void registerColumn(BlockStateModelGenerator modelGenerator, Block block, Block base) {
-		TextureMap textures = getTextures(base);
+	public static void registerColumn(BlockModelGenerators modelGenerator, Block block, Block base) {
+		TextureMapping textures = getTextures(base);
 
-		Identifier centerId = COLUMN_CENTER.upload(block, textures, modelGenerator.modelCollector);
-		Identifier endId = COLUMN_END.upload(block, textures, modelGenerator.modelCollector);
+		Identifier centerId = COLUMN_CENTER.create(block, textures, modelGenerator.modelOutput);
+		Identifier endId = COLUMN_END.create(block, textures, modelGenerator.modelOutput);
 
-		modelGenerator.blockStateCollector.accept(MultipartBlockStateSupplier.create(block)
+		modelGenerator.blockStateOutput.accept(MultipartBlockStateSupplier.create(block)
 			.with(createVariant(centerId))
 			.with(When.create().set(ColumnBlock.DOWN, true), createVariant(endId))
 			.with(When.create().set(ColumnBlock.UP, true), createVariantRotated(endId)));
 
-		Identifier inventoryId = COLUMN_INVENTORY.upload(block, textures, modelGenerator.modelCollector);
-		modelGenerator.registerParentedItemModel(block, inventoryId);
+		Identifier inventoryId = COLUMN_INVENTORY.create(block, textures, modelGenerator.modelOutput);
+		modelGenerator.registerSimpleItemModel(block, inventoryId);
 	}
 
-	private static TextureMap getTextures(Block base) {
+	private static TextureMapping getTextures(Block base) {
 		if (base == Blocks.SANDSTONE || base == Blocks.RED_SANDSTONE) {
-			return TextureMap.all(TextureMap.getSubId(base, "_top"));
+			return TextureMapping.cube(TextureMapping.getBlockTexture(base, "_top"));
 		}
-		return TextureMap.all(base);
+		return TextureMapping.cube(base);
 	}
 
 	private static BlockStateVariant createVariant(Identifier modelId) {
@@ -73,7 +73,7 @@ public class ColumnsModelProvider extends FabricModelProvider {
 			.put(VariantSettings.UVLOCK, true);
 	}
 
-	private static Model createModel(String parent, String variant, TextureKey... requiredTextures) {
-		return new Model(Optional.of(Main.id("block/" + parent)), Optional.of(variant), requiredTextures);
+	private static ModelTemplate createModel(String parent, String variant, TextureSlot... requiredTextures) {
+		return new ModelTemplate(Optional.of(Main.id("block/" + parent)), Optional.of(variant), requiredTextures);
 	}
 }

--- a/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsModelProvider.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsModelProvider.java
@@ -6,17 +6,19 @@ import io.github.haykam821.columns.Main;
 import io.github.haykam821.columns.block.ColumnBlock;
 import io.github.haykam821.columns.block.ColumnTypes;
 import net.fabricmc.fabric.api.client.datagen.v1.provider.FabricModelProvider;
-import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
-import net.minecraft.client.data.BlockStateVariant;
-import net.minecraft.client.data.MultipartBlockStateSupplier;
-import net.minecraft.client.data.VariantSettings;
-import net.minecraft.client.data.When;
+import net.fabricmc.fabric.api.datagen.v1.FabricPackOutput;
 import net.minecraft.client.data.models.BlockModelGenerators;
 import net.minecraft.client.data.models.ItemModelGenerators;
+import net.minecraft.client.data.models.MultiVariant;
+import net.minecraft.client.data.models.blockstates.ConditionBuilder;
+import net.minecraft.client.data.models.blockstates.MultiPartGenerator;
 import net.minecraft.client.data.models.model.ModelTemplate;
 import net.minecraft.client.data.models.model.TextureMapping;
 import net.minecraft.client.data.models.model.TextureSlot;
+import net.minecraft.client.renderer.block.model.Variant;
+import net.minecraft.client.renderer.block.model.VariantMutator;
 import net.minecraft.resources.Identifier;
+import net.minecraft.util.random.WeightedList;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 
@@ -25,7 +27,7 @@ public class ColumnsModelProvider extends FabricModelProvider {
 	public static final ModelTemplate COLUMN_END = createModel("column_end", "_end", TextureSlot.ALL);
 	public static final ModelTemplate COLUMN_INVENTORY = createModel("column_inventory", "_inventory", TextureSlot.ALL);
 
-	public ColumnsModelProvider(FabricDataOutput dataOutput) {
+	public ColumnsModelProvider(FabricPackOutput dataOutput) {
 		super(dataOutput);
 	}
 
@@ -47,10 +49,10 @@ public class ColumnsModelProvider extends FabricModelProvider {
 		Identifier centerId = COLUMN_CENTER.create(block, textures, modelGenerator.modelOutput);
 		Identifier endId = COLUMN_END.create(block, textures, modelGenerator.modelOutput);
 
-		modelGenerator.blockStateOutput.accept(MultipartBlockStateSupplier.create(block)
+		modelGenerator.blockStateOutput.accept(MultiPartGenerator.multiPart(block)
 			.with(createVariant(centerId))
-			.with(When.create().set(ColumnBlock.DOWN, true), createVariant(endId))
-			.with(When.create().set(ColumnBlock.UP, true), createVariantRotated(endId)));
+			.with(new ConditionBuilder().term(ColumnBlock.DOWN, true), createVariant(endId))
+			.with(new ConditionBuilder().term(ColumnBlock.UP, true), createVariantRotated(endId)));
 
 		Identifier inventoryId = COLUMN_INVENTORY.create(block, textures, modelGenerator.modelOutput);
 		modelGenerator.registerSimpleItemModel(block, inventoryId);
@@ -63,14 +65,14 @@ public class ColumnsModelProvider extends FabricModelProvider {
 		return TextureMapping.cube(base);
 	}
 
-	private static BlockStateVariant createVariant(Identifier modelId) {
-		return BlockStateVariant.create().put(VariantSettings.MODEL, modelId);
+	private static MultiVariant createVariant(Identifier modelId) {
+		return new MultiVariant(WeightedList.of(new Variant(modelId)));
 	}
 
-	private static BlockStateVariant createVariantRotated(Identifier modelId) {
+	private static MultiVariant createVariantRotated(Identifier modelId) {
 		return createVariant(modelId)
-			.put(VariantSettings.X, VariantSettings.Rotation.R180)
-			.put(VariantSettings.UVLOCK, true);
+			.with(BlockModelGenerators.X_ROT_180)
+			.with(BlockModelGenerators.UV_LOCK);
 	}
 
 	private static ModelTemplate createModel(String parent, String variant, TextureSlot... requiredTextures) {

--- a/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsRecipeGenerator.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsRecipeGenerator.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import io.github.haykam821.columns.block.ColumnTypes;
-import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.FabricPackOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
@@ -107,8 +107,7 @@ public class ColumnsRecipeGenerator extends RecipeProvider {
 	}
 
 	private void offerCraftingTo(ShapedRecipeBuilder factory) {
-		Identifier recipeId = RecipeBuilder.getDefaultRecipeId(factory.getResult());
-		ResourceKey<Recipe<?>> recipeKey = ResourceKey.create(Registries.RECIPE, recipeId);
+		ResourceKey<Recipe<?>> recipeKey = RecipeBuilder.getDefaultRecipeId(factory.result);
 
 		this.offerShapedTo(recipeKey, factory);
 	}
@@ -128,9 +127,8 @@ public class ColumnsRecipeGenerator extends RecipeProvider {
 
 		String group = Objects.requireNonNullElse(factory.group, "");
 		CraftingBookCategory category = RecipeBuilder.determineBookCategory(factory.category);
-		ItemStack output = new ItemStack(factory.getResult(), factory.count);
 
-		ShapedRecipe recipe = new ShapedRecipe(group, category, rawRecipe, output, factory.showNotification);
+		ShapedRecipe recipe = new ShapedRecipe(group, category, rawRecipe, factory.result, factory.showNotification);
 		this.output.accept(recipeKey, recipe, advancement);
 	}
 
@@ -148,9 +146,8 @@ public class ColumnsRecipeGenerator extends RecipeProvider {
 		AdvancementHolder advancement = advancementBuilder.build(advancementId);
 
 		String group = Objects.requireNonNullElse(factory.group, "");
-		ItemStack output = new ItemStack(factory.getResult(), factory.count);
 
-		SingleItemRecipe recipe = factory.factory.create(group, factory.ingredient, output);
+		SingleItemRecipe recipe = factory.factory.create(group, factory.ingredient, factory.result);
 		this.output.accept(recipeKey, recipe, advancement);
 	}
 
@@ -159,7 +156,7 @@ public class ColumnsRecipeGenerator extends RecipeProvider {
 	}
 
 	public static class Provider extends FabricRecipeProvider {
-		public Provider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries) {
+		public Provider(FabricPackOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries) {
 			super(dataOutput, registries);
 		}
 

--- a/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsRecipeGenerator.java
+++ b/src/datagen/java/io/github/haykam821/columns/data/provider/ColumnsRecipeGenerator.java
@@ -6,40 +6,40 @@ import java.util.concurrent.CompletableFuture;
 import io.github.haykam821.columns.block.ColumnTypes;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider;
-import net.minecraft.advancement.Advancement;
-import net.minecraft.advancement.AdvancementEntry;
-import net.minecraft.advancement.AdvancementRequirements.CriterionMerger;
-import net.minecraft.advancement.AdvancementRewards;
-import net.minecraft.advancement.criterion.RecipeUnlockedCriterion;
-import net.minecraft.block.Block;
-import net.minecraft.block.Blocks;
-import net.minecraft.data.recipe.CraftingRecipeJsonBuilder;
-import net.minecraft.data.recipe.RecipeExporter;
-import net.minecraft.data.recipe.RecipeGenerator;
-import net.minecraft.data.recipe.ShapedRecipeJsonBuilder;
-import net.minecraft.data.recipe.StonecuttingRecipeJsonBuilder;
-import net.minecraft.item.ItemConvertible;
-import net.minecraft.item.ItemStack;
-import net.minecraft.recipe.Ingredient;
-import net.minecraft.recipe.RawShapedRecipe;
-import net.minecraft.recipe.Recipe;
-import net.minecraft.recipe.ShapedRecipe;
-import net.minecraft.recipe.SingleStackRecipe;
-import net.minecraft.recipe.book.CraftingRecipeCategory;
-import net.minecraft.recipe.book.RecipeCategory;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.registry.RegistryKeys;
-import net.minecraft.registry.RegistryWrapper;
-import net.minecraft.util.Identifier;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementRequirements.Strategy;
+import net.minecraft.advancements.AdvancementRewards;
+import net.minecraft.advancements.criterion.RecipeUnlockedTrigger;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.recipes.RecipeBuilder;
+import net.minecraft.data.recipes.RecipeCategory;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.RecipeProvider;
+import net.minecraft.data.recipes.ShapedRecipeBuilder;
+import net.minecraft.data.recipes.SingleItemRecipeBuilder;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import net.minecraft.world.item.crafting.ShapedRecipePattern;
+import net.minecraft.world.item.crafting.SingleItemRecipe;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 
-public class ColumnsRecipeGenerator extends RecipeGenerator {
-	protected ColumnsRecipeGenerator(RegistryWrapper.WrapperLookup registries, RecipeExporter exporter) {
+public class ColumnsRecipeGenerator extends RecipeProvider {
+	protected ColumnsRecipeGenerator(HolderLookup.Provider registries, RecipeOutput exporter) {
 		super(registries, exporter);
 	}
 
 	@Override
-	public void generate() {
+	public void buildRecipes() {
 		for (ColumnTypes columnType : ColumnTypes.values()) {
 			this.offerColumnRecipe(columnType.block, columnType.base);
 			this.offerColumnStonecuttingRecipe(columnType.block, columnType.base);
@@ -70,101 +70,101 @@ public class ColumnsRecipeGenerator extends RecipeGenerator {
 	}
 
 	public void offerColumnRecipe(Block block, Block base) {
-		this.offerCraftingTo(this.getColumnRecipe(block, Ingredient.ofItems(base))
-			.criterion(RecipeGenerator.hasItem(base), this.conditionsFromItem(base)));
+		this.offerCraftingTo(this.getColumnRecipe(block, Ingredient.of(base))
+			.unlockedBy(RecipeProvider.getHasName(base), this.has(base)));
 	}
 
-	public ShapedRecipeJsonBuilder getColumnRecipe(ItemConvertible output, Ingredient input) {
-		return this.createShaped(RecipeCategory.DECORATIONS, output, 6)
-			.input('#', input)
+	public ShapedRecipeBuilder getColumnRecipe(ItemLike output, Ingredient input) {
+		return this.shaped(RecipeCategory.DECORATIONS, output, 6)
+			.define('#', input)
 			.pattern("###")
 			.pattern(" # ")
 			.pattern("###");
 	}
 
 	public void offerColumnStonecuttingRecipe(Block block, Block base) {
-		Identifier blockId = Registries.ITEM.getId(block.asItem());
+		Identifier blockId = BuiltInRegistries.ITEM.getKey(block.asItem());
 
-		Identifier recipeId = blockId.withSuffixedPath("_from_stonecutting");
-		RegistryKey<Recipe<?>> recipeKey = RegistryKey.of(RegistryKeys.RECIPE, recipeId);
+		Identifier recipeId = blockId.withSuffix("_from_stonecutting");
+		ResourceKey<Recipe<?>> recipeKey = ResourceKey.create(Registries.RECIPE, recipeId);
 
 		this.offerCustomColumnStonecuttingRecipe(recipeKey, block, base);
 	}
 
 	public void offerCustomColumnStonecuttingRecipe(Block block, Block base) {
-		Identifier baseId = Registries.ITEM.getId(base.asItem());
-		Identifier blockId = Registries.ITEM.getId(block.asItem());
+		Identifier baseId = BuiltInRegistries.ITEM.getKey(base.asItem());
+		Identifier blockId = BuiltInRegistries.ITEM.getKey(block.asItem());
 
 		Identifier recipeId = blockId.withPath(path -> path + "_from_" + baseId.getPath() + "_stonecutting");
-		RegistryKey<Recipe<?>> recipeKey = RegistryKey.of(RegistryKeys.RECIPE, recipeId);
+		ResourceKey<Recipe<?>> recipeKey = ResourceKey.create(Registries.RECIPE, recipeId);
 
 		this.offerCustomColumnStonecuttingRecipe(recipeKey, block, base);
 	}
 
-	private void offerCustomColumnStonecuttingRecipe(RegistryKey<Recipe<?>> recipeKey, Block block, Block base) {
-		this.offerSingleItemTo(recipeKey, StonecuttingRecipeJsonBuilder.createStonecutting(Ingredient.ofItems(base), RecipeCategory.DECORATIONS, block, 1)
-			.criterion(RecipeGenerator.hasItem(base), this.conditionsFromItem(base)));
+	private void offerCustomColumnStonecuttingRecipe(ResourceKey<Recipe<?>> recipeKey, Block block, Block base) {
+		this.offerSingleItemTo(recipeKey, SingleItemRecipeBuilder.stonecutting(Ingredient.of(base), RecipeCategory.DECORATIONS, block, 1)
+			.unlockedBy(RecipeProvider.getHasName(base), this.has(base)));
 	}
 
-	private void offerCraftingTo(ShapedRecipeJsonBuilder factory) {
-		Identifier recipeId = CraftingRecipeJsonBuilder.getItemId(factory.getOutputItem());
-		RegistryKey<Recipe<?>> recipeKey = RegistryKey.of(RegistryKeys.RECIPE, recipeId);
+	private void offerCraftingTo(ShapedRecipeBuilder factory) {
+		Identifier recipeId = RecipeBuilder.getDefaultRecipeId(factory.getResult());
+		ResourceKey<Recipe<?>> recipeKey = ResourceKey.create(Registries.RECIPE, recipeId);
 
 		this.offerShapedTo(recipeKey, factory);
 	}
 
-	private void offerShapedTo(RegistryKey<Recipe<?>> recipeKey, ShapedRecipeJsonBuilder factory) {
-		RawShapedRecipe rawRecipe = factory.validate(recipeKey);
+	private void offerShapedTo(ResourceKey<Recipe<?>> recipeKey, ShapedRecipeBuilder factory) {
+		ShapedRecipePattern rawRecipe = factory.ensureValid(recipeKey);
 
 		Identifier advancementId = ColumnsRecipeGenerator.getAdvancementId(recipeKey);
-		Advancement.Builder advancementBuilder = this.exporter.getAdvancementBuilder()
-			.criterion("has_the_recipe", RecipeUnlockedCriterion.create(recipeKey))
+		Advancement.Builder advancementBuilder = this.output.advancement()
+			.addCriterion("has_the_recipe", RecipeUnlockedTrigger.unlocked(recipeKey))
 			.rewards(AdvancementRewards.Builder.recipe(recipeKey))
-			.criteriaMerger(CriterionMerger.OR);
+			.requirements(Strategy.OR);
 
-		factory.criteria.forEach(advancementBuilder::criterion);
+		factory.criteria.forEach(advancementBuilder::addCriterion);
 
-		AdvancementEntry advancement = advancementBuilder.build(advancementId);
+		AdvancementHolder advancement = advancementBuilder.build(advancementId);
 
 		String group = Objects.requireNonNullElse(factory.group, "");
-		CraftingRecipeCategory category = CraftingRecipeJsonBuilder.toCraftingCategory(factory.category);
-		ItemStack output = new ItemStack(factory.getOutputItem(), factory.count);
+		CraftingBookCategory category = RecipeBuilder.determineBookCategory(factory.category);
+		ItemStack output = new ItemStack(factory.getResult(), factory.count);
 
 		ShapedRecipe recipe = new ShapedRecipe(group, category, rawRecipe, output, factory.showNotification);
-		this.exporter.accept(recipeKey, recipe, advancement);
+		this.output.accept(recipeKey, recipe, advancement);
 	}
 
-	private void offerSingleItemTo(RegistryKey<Recipe<?>> recipeKey, StonecuttingRecipeJsonBuilder factory) {
-		factory.validate(recipeKey);
+	private void offerSingleItemTo(ResourceKey<Recipe<?>> recipeKey, SingleItemRecipeBuilder factory) {
+		factory.ensureValid(recipeKey);
 
 		Identifier advancementId = ColumnsRecipeGenerator.getAdvancementId(recipeKey);
-		Advancement.Builder advancementBuilder = this.exporter.getAdvancementBuilder()
-			.criterion("has_the_recipe", RecipeUnlockedCriterion.create(recipeKey))
+		Advancement.Builder advancementBuilder = this.output.advancement()
+			.addCriterion("has_the_recipe", RecipeUnlockedTrigger.unlocked(recipeKey))
 			.rewards(AdvancementRewards.Builder.recipe(recipeKey))
-			.criteriaMerger(CriterionMerger.OR);
+			.requirements(Strategy.OR);
 
-		factory.criteria.forEach(advancementBuilder::criterion);
+		factory.criteria.forEach(advancementBuilder::addCriterion);
 
-		AdvancementEntry advancement = advancementBuilder.build(advancementId);
+		AdvancementHolder advancement = advancementBuilder.build(advancementId);
 
 		String group = Objects.requireNonNullElse(factory.group, "");
-		ItemStack output = new ItemStack(factory.getOutputItem(), factory.count);
+		ItemStack output = new ItemStack(factory.getResult(), factory.count);
 
-		SingleStackRecipe recipe = factory.recipeFactory.create(group, factory.input, output);
-		this.exporter.accept(recipeKey, recipe, advancement);
+		SingleItemRecipe recipe = factory.factory.create(group, factory.ingredient, output);
+		this.output.accept(recipeKey, recipe, advancement);
 	}
 
-	private static Identifier getAdvancementId(RegistryKey<Recipe<?>> recipeKey) {
-		return recipeKey.getValue().withPrefixedPath("recipes/");
+	private static Identifier getAdvancementId(ResourceKey<Recipe<?>> recipeKey) {
+		return recipeKey.identifier().withPrefix("recipes/");
 	}
 
 	public static class Provider extends FabricRecipeProvider {
-		public Provider(FabricDataOutput dataOutput, CompletableFuture<RegistryWrapper.WrapperLookup> registries) {
+		public Provider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registries) {
 			super(dataOutput, registries);
 		}
 
 		@Override
-		protected RecipeGenerator getRecipeGenerator(RegistryWrapper.WrapperLookup registries, RecipeExporter exporter) {
+		protected RecipeProvider createRecipeProvider(HolderLookup.Provider registries, RecipeOutput exporter) {
 			return new ColumnsRecipeGenerator(registries, exporter);
 		}
 

--- a/src/main/java/io/github/haykam821/columns/Main.java
+++ b/src/main/java/io/github/haykam821/columns/Main.java
@@ -3,32 +3,32 @@ package io.github.haykam821.columns;
 import io.github.haykam821.columns.block.ColumnBlock;
 import io.github.haykam821.columns.block.ColumnTypes;
 import net.fabricmc.api.ModInitializer;
-import net.minecraft.block.Block;
-import net.minecraft.item.Item;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.Registry;
-import net.minecraft.registry.RegistryKeys;
-import net.minecraft.registry.tag.TagKey;
-import net.minecraft.util.Identifier;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
 
 public class Main implements ModInitializer {
 	private static final String MOD_ID = "columns";
 
 	private static final Identifier COLUMNS_ID = Main.id("columns");
 
-	public static final TagKey<Block> COLUMNS_BLOCK_TAG = TagKey.of(RegistryKeys.BLOCK, COLUMNS_ID);
-	public static final TagKey<Item> COLUMNS_ITEM_TAG = TagKey.of(RegistryKeys.ITEM, COLUMNS_ID);
+	public static final TagKey<Block> COLUMNS_BLOCK_TAG = TagKey.create(Registries.BLOCK, COLUMNS_ID);
+	public static final TagKey<Item> COLUMNS_ITEM_TAG = TagKey.create(Registries.ITEM, COLUMNS_ID);
 
 	private static final Identifier COLUMN_ID = Main.id("column");
 
 	@Override
 	public void onInitialize() {
-		Registry.register(Registries.BLOCK_TYPE, COLUMN_ID, ColumnBlock.CODEC);
+		Registry.register(BuiltInRegistries.BLOCK_TYPE, COLUMN_ID, ColumnBlock.CODEC);
 
 		ColumnTypes.register();
 	}
 
 	public static Identifier id(String path) {
-		return Identifier.of(MOD_ID, path);
+		return Identifier.fromNamespaceAndPath(MOD_ID, path);
 	}
 }

--- a/src/main/java/io/github/haykam821/columns/block/ColumnTypes.java
+++ b/src/main/java/io/github/haykam821/columns/block/ColumnTypes.java
@@ -1,7 +1,7 @@
 package io.github.haykam821.columns.block;
 
 import io.github.haykam821.columns.Main;
-import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.fabricmc.fabric.api.creativetab.v1.CreativeModeTabEvents;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -69,9 +69,9 @@ public enum ColumnTypes {
 	}
 
 	public static void register() {
-		ItemGroupEvents.modifyEntriesEvent(CreativeModeTabs.BUILDING_BLOCKS).register(entries -> {
+		CreativeModeTabEvents.modifyOutputEvent(CreativeModeTabs.BUILDING_BLOCKS).register(entries -> {
 			for (ColumnTypes type : ColumnTypes.values()) {
-				entries.addBefore(type.wall, type.item);
+				entries.insertBefore(type.wall, type.item);
 			}
 		});
 	}

--- a/src/main/java/io/github/haykam821/columns/block/ColumnTypes.java
+++ b/src/main/java/io/github/haykam821/columns/block/ColumnTypes.java
@@ -2,17 +2,18 @@ package io.github.haykam821.columns.block;
 
 import io.github.haykam821.columns.Main;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
-import net.minecraft.block.Block;
-import net.minecraft.block.Blocks;
-import net.minecraft.item.BlockItem;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemGroups;
-import net.minecraft.item.Items;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.Registry;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.registry.RegistryKeys;
-import net.minecraft.util.Identifier;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 
 public enum ColumnTypes {
 	TUFF("tuff", Blocks.TUFF, Items.TUFF_WALL),
@@ -52,23 +53,23 @@ public enum ColumnTypes {
 		this.base = base;
 		this.wall = wall;
 
-		Block.Settings blockSettings = Block.Settings.copy(base)
-			.registryKey(RegistryKey.of(RegistryKeys.BLOCK, id));
+		BlockBehaviour.Properties blockSettings = BlockBehaviour.Properties.ofFullCopy(base)
+			.setId(ResourceKey.create(Registries.BLOCK, id));
 
 		this.block = new ColumnBlock(blockSettings);
 
-		Item.Settings itemSettings = new Item.Settings()
-			.registryKey(RegistryKey.of(RegistryKeys.ITEM, id))
-			.useBlockPrefixedTranslationKey();
+		Item.Properties itemSettings = new Item.Properties()
+			.setId(ResourceKey.create(Registries.ITEM, id))
+			.useBlockDescriptionPrefix();
 
 		this.item = new BlockItem(this.block, itemSettings);
 
-		Registry.register(Registries.BLOCK, id, this.block);
-		Registry.register(Registries.ITEM, id, this.item);
+		Registry.register(BuiltInRegistries.BLOCK, id, this.block);
+		Registry.register(BuiltInRegistries.ITEM, id, this.item);
 	}
 
 	public static void register() {
-		ItemGroupEvents.modifyEntriesEvent(ItemGroups.BUILDING_BLOCKS).register(entries -> {
+		ItemGroupEvents.modifyEntriesEvent(CreativeModeTabs.BUILDING_BLOCKS).register(entries -> {
 			for (ColumnTypes type : ColumnTypes.values()) {
 				entries.addBefore(type.wall, type.item);
 			}

--- a/src/main/resources/columns.accesswidener
+++ b/src/main/resources/columns.accesswidener
@@ -1,15 +1,17 @@
-accessWidener	v2	named
+accessWidener	v2	official
 
 accessible	method	net/minecraft/data/recipes/ShapedRecipeBuilder	ensureValid	(Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/world/item/crafting/ShapedRecipePattern;
 accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	group	Ljava/lang/String;
 accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	criteria	Ljava/util/Map;
 accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	category	Lnet/minecraft/data/recipes/RecipeCategory;
 accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	showNotification	Z
-accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	count	I
+accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	result	Lnet/minecraft/world/item/ItemStackTemplate;
 
 accessible	method	net/minecraft/data/recipes/SingleItemRecipeBuilder	ensureValid	(Lnet/minecraft/resources/ResourceKey;)V
 accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	criteria	Ljava/util/Map;
 accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	group	Ljava/lang/String;
 accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	ingredient	Lnet/minecraft/world/item/crafting/Ingredient;
-accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	count	I
+accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	result	Lnet/minecraft/world/item/ItemStackTemplate;
 accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	factory	Lnet/minecraft/world/item/crafting/SingleItemRecipe$Factory;
+
+accessible field net/minecraft/data/loot/BlockLootSubProvider map Ljava/util/Map;

--- a/src/main/resources/columns.accesswidener
+++ b/src/main/resources/columns.accesswidener
@@ -1,15 +1,15 @@
 accessWidener	v2	named
 
-accessible	method	net/minecraft/data/recipe/ShapedRecipeJsonBuilder	validate	(Lnet/minecraft/registry/RegistryKey;)Lnet/minecraft/recipe/RawShapedRecipe;
-accessible	field	net/minecraft/data/recipe/ShapedRecipeJsonBuilder	group	Ljava/lang/String;
-accessible	field	net/minecraft/data/recipe/ShapedRecipeJsonBuilder	criteria	Ljava/util/Map;
-accessible	field	net/minecraft/data/recipe/ShapedRecipeJsonBuilder	category	Lnet/minecraft/recipe/book/RecipeCategory;
-accessible	field	net/minecraft/data/recipe/ShapedRecipeJsonBuilder	showNotification	Z
-accessible	field	net/minecraft/data/recipe/ShapedRecipeJsonBuilder	count	I
+accessible	method	net/minecraft/data/recipes/ShapedRecipeBuilder	ensureValid	(Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/world/item/crafting/ShapedRecipePattern;
+accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	group	Ljava/lang/String;
+accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	criteria	Ljava/util/Map;
+accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	category	Lnet/minecraft/data/recipes/RecipeCategory;
+accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	showNotification	Z
+accessible	field	net/minecraft/data/recipes/ShapedRecipeBuilder	count	I
 
-accessible	method	net/minecraft/data/recipe/StonecuttingRecipeJsonBuilder	validate	(Lnet/minecraft/registry/RegistryKey;)V
-accessible	field	net/minecraft/data/recipe/StonecuttingRecipeJsonBuilder	criteria	Ljava/util/Map;
-accessible	field	net/minecraft/data/recipe/StonecuttingRecipeJsonBuilder	group	Ljava/lang/String;
-accessible	field	net/minecraft/data/recipe/StonecuttingRecipeJsonBuilder	input	Lnet/minecraft/recipe/Ingredient;
-accessible	field	net/minecraft/data/recipe/StonecuttingRecipeJsonBuilder	count	I
-accessible	field	net/minecraft/data/recipe/StonecuttingRecipeJsonBuilder	recipeFactory	Lnet/minecraft/recipe/SingleStackRecipe$RecipeFactory;
+accessible	method	net/minecraft/data/recipes/SingleItemRecipeBuilder	ensureValid	(Lnet/minecraft/resources/ResourceKey;)V
+accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	criteria	Ljava/util/Map;
+accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	group	Ljava/lang/String;
+accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	ingredient	Lnet/minecraft/world/item/crafting/Ingredient;
+accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	count	I
+accessible	field	net/minecraft/data/recipes/SingleItemRecipeBuilder	factory	Lnet/minecraft/world/item/crafting/SingleItemRecipe$Factory;


### PR DESCRIPTION
The existing build on Modrinth works for 1.21.4 to 1.21.11 (feel free to mark it as such on Modrinth!), but as 26.1 removes obfuscation the mod needed to be migrated to official mappings and the unobfuscated version of Fabric API. Use as you will, built this primarily to make sure Columns/Pyrite continued to function together on 26.1 and above.